### PR TITLE
Please fix ComponentNext -> ComponentNest

### DIFF
--- a/projects/component-next/README.md
+++ b/projects/component-next/README.md
@@ -1,4 +1,4 @@
-# ComponentNext
+# ComponentNest
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 6.0.0.
 


### PR DESCRIPTION
This example seems to have been misnamed. It should have been ComponentNest. I can't rename the folder to fix this for you from the github ui: Example 14 on http://angular2-first-look.azurewebsites.net/ and obviously there are more files to change. It was an issue raised by one of your users on StackBlitz's issues. Sorry I've no time to raise the full PR for you.